### PR TITLE
Updating the anchore-engine chart

### DIFF
--- a/anchore-policy-validator/requirements.lock
+++ b/anchore-policy-validator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: anchore-engine
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.1.1
+  version: 0.1.7
 digest: sha256:b87d17f367a89fd354476216786f9d757952f8e2262e470f278cc544e2fbd297
-generated: 2018-01-29T15:05:06.578988266-08:00
+generated: 2018-06-11T15:26:56.853403616-04:00


### PR DESCRIPTION
Installing the chart as is, the core engine fails to start. Presumably due to issues addressed with this PR: https://github.com/kubernetes/charts/pull/4802. Updating the dependency to current anchore-engine release fixes the issue.