### PR TITLE
Tag fixes and bump chart dependency on anchore

### DIFF
--- a/anchore-policy-validator/requirements.lock
+++ b/anchore-policy-validator/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: anchore-engine
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.1.7
-digest: sha256:b87d17f367a89fd354476216786f9d757952f8e2262e470f278cc544e2fbd297
-generated: 2018-06-11T15:26:56.853403616-04:00
+  version: 0.2.1
+digest: sha256:6e70f4339a1dc997c564f09d8cbaf8f7881dec04dc636c561e2ebc209dd85fb3
+generated: 2018-09-12T00:23:32.077085747-07:00

--- a/anchore-policy-validator/requirements.yaml
+++ b/anchore-policy-validator/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: anchore-engine
-  version: 0.1.x
+  version: 0.2.x
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: anchore-engine.enabled

--- a/cmd/anchore-image-admission-server/main.go
+++ b/cmd/anchore-image-admission-server/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"sync"
-
 	"encoding/json"
 	"fmt"
 	"github.com/golang/glog"
 	"github.com/openshift/generic-admission-server/pkg/cmd"
 	"github.com/viglesiasce/anchore-image-admission-server/pkg/anchore"
+	// Testing Only: "github.com/viglesiasce/kubernetes-anchore-image-validator/pkg/anchore"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/cmd/anchore-image-admission-server/main_test.go
+++ b/cmd/anchore-image-admission-server/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/golang/glog"
+	"k8s.io/api/admission/v1beta1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"testing"
+)
+
+
+func TestValidate(t *testing.T) {
+	tpod := &v1.Pod{
+		Spec: v1.PodSpec{Containers: []v1.Container{
+			{
+				Name:    "Container1",
+				Image:   "ubuntu",
+				Command: []string{"bin/bash", "bin"},
+			},
+		},
+		},
+	}
+
+	marshalledPod, err := json.Marshal(tpod)
+
+	if (err != nil ) {
+		glog.Error("Failed marshalling pod spec")
+		t.Error("Failed marshalling")
+	}
+
+	admSpec := v1beta1.AdmissionRequest {
+		UID: "abc123",
+		Kind: metav1.GroupVersionKind{Group: v1beta1.GroupName, Version: v1beta1.SchemeGroupVersion.Version, Kind: "Pod"},
+		Resource: metav1.GroupVersionResource{Group: metav1.GroupName, Version: "v1", Resource: "pods"},
+		SubResource: "someresource",
+		Name: "somename",
+		Namespace: "default",
+		Operation: "CREATE",
+		Object: runtime.RawExtension{Raw: marshalledPod},
+	}
+
+	adm := admissionHook{}
+	resp := adm.Validate(&admSpec)
+	obj, err := json.Marshal(resp)
+
+	if(err == nil) {
+		fmt.Println(string(obj[:]))
+	}
+
+}

--- a/pkg/anchore/client.go
+++ b/pkg/anchore/client.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 )
 
@@ -55,9 +56,18 @@ func getStatus(digest string, tag string) bool {
 		return false
 	}
 
+	foundStatus := FindResult(result)
+
 	// Is this the easiest way to get this info?
-	resultIndex := fmt.Sprintf("docker.io/%s:latest", tag)
-	return result[0][digest][resultIndex][0].Status == "pass"
+	return strings.ToLower(foundStatus) == "pass"
+}
+
+func FindResult(parsed_result []map[string]map[string][]SHAResult) string {
+	//Looks thru a parsed result for the status value, assumes this result is for a single image
+
+	digest := reflect.ValueOf(parsed_result[0]).MapKeys()[0].String()
+	tag := reflect.ValueOf(parsed_result[0][digest]).MapKeys()[0].String()
+	return parsed_result[0][digest][tag][0].Status
 }
 
 func getImage(imageRef string) (Image, error) {
@@ -94,15 +104,15 @@ func AddImage(image string) error {
 }
 
 func CheckImage(image string) bool {
-	imageParts := strings.Split(image, ":")
-	tag := "latest"
-	if len(imageParts) > 1 {
-		tag = imageParts[1]
-	}
+	//imageParts := strings.Split(image, ":")
+	//tag := "latest"
+	//if len(imageParts) > 1 {
+	//	tag = imageParts[1]
+	//}
 	digest, err := getImageDigest(image)
 	if err != nil {
 		AddImage(image)
 		return false
 	}
-	return getStatus(digest, tag)
+	return getStatus(digest, image)
 }

--- a/pkg/anchore/client.go
+++ b/pkg/anchore/client.go
@@ -104,11 +104,6 @@ func AddImage(image string) error {
 }
 
 func CheckImage(image string) bool {
-	//imageParts := strings.Split(image, ":")
-	//tag := "latest"
-	//if len(imageParts) > 1 {
-	//	tag = imageParts[1]
-	//}
 	digest, err := getImageDigest(image)
 	if err != nil {
 		AddImage(image)

--- a/pkg/anchore/client_test.go
+++ b/pkg/anchore/client_test.go
@@ -1,7 +1,9 @@
 package anchore
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/golang/glog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,10 +18,10 @@ func setupEnv(url string) {
 
 func TestGetStatus(t *testing.T) {
 	digest := "sha256:1d8f14b6d4e01369e1df18cfae17eb0894a39a21c28c6f8dbf6e2fe895b36522"
-	tag := "latest"
+	tag := "docker.io/somerepo/someimage:latest"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `[{"%s":{"docker.io/%s:latest": [{"status":"pass"}]}}]`, digest, tag)
+		fmt.Fprintf(w, `[{"%s":{"%s": [{"status":"pass"}]}}]`, digest, tag)
 	}))
 	defer ts.Close()
 
@@ -52,4 +54,17 @@ func TestGetDigest(t *testing.T) {
 		t.Logf("getImageDigest returned wrong digest: %s", digestResult)
 		t.Fail()
 	}
+}
+
+func TestTagParse(t *testing.T) {
+	exampleResult := "[{\"sha256:abc123\": {\"docker.io/alpine:3.7\": [{\"detail\": {},\"last_evaluation\": \"2018-10-25T08:01:24Z\",\"policyId\": \"default\",\"status\": \"pass\"}]}}]"
+	body := []byte(exampleResult)
+	var result []map[string]map[string][]SHAResult
+	err := json.Unmarshal(body, &result)
+	if err != nil {
+		glog.Error(err)
+		t.Fail()
+	}
+	status := FindResult(result)
+	t.Log("Found status: ", status)
 }


### PR DESCRIPTION
Fixes some issues with different tag strings. In the current impl it's possible to have a tag "alpine:3.7" and the validator will submit it to anchore but look for a "docker.io/3.7" tag in the response. This fix omits the tag mapping on submission to anchore and since the subsequent tag parameter to the policy evaluation is symmetric it just uses the response elements removing the need to re-parse the tag string and lookup. This handles the case where anchore automatically adds registry and/or "latest" to tag. E.g. submit "alpine" to anchore and the tag it uses as a key is "docker.io/alpine:latest". This handles that behavior.